### PR TITLE
changed to pull ogg and vorbis source from repositories

### DIFF
--- a/docker/Dockerfile.source
+++ b/docker/Dockerfile.source
@@ -45,8 +45,7 @@ RUN  wget -O - ${YASM_REPO} | tar xz && \
 
 # Build ogg
 ARG OGG_VER=1.3.3
-ARG OGG_REPO=https://downloads.xiph.org/releases/ogg/libogg-${OGG_VER}.tar.xz
-
+ARG OGG_REPO=https://github.com/xiph/ogg/releases/download/v${OGG_VER}/libogg-${OGG_VER}.tar.xz
 RUN wget -O - ${OGG_REPO} | tar xJ && \
     cd libogg-${OGG_VER} && \
     ./configure --prefix="/usr/local" --libdir=/usr/local/lib/x86_64-linux-gnu --enable-shared && \
@@ -56,10 +55,10 @@ RUN wget -O - ${OGG_REPO} | tar xJ && \
 
 # Build vorbis
 ARG VORBIS_VER=1.3.6
-ARG VORBIS_REPO=https://downloads.xiph.org/releases/vorbis/libvorbis-${VORBIS_VER}.tar.xz
-
-RUN wget -O - ${VORBIS_REPO} | tar xJ && \
-    cd libvorbis-${VORBIS_VER} && \
+ARG VORBIS_REPO=https://github.com/xiph/vorbis/archive/v${VORBIS_VER}.tar.gz
+RUN wget -O - ${VORBIS_REPO} | tar xz && \
+    cd vorbis-${VORBIS_VER} && \
+    ./autogen.sh && \
     export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib/x86_64-linux-gnu && \
     ./configure --prefix="/usr/local" --libdir=/usr/local/lib/x86_64-linux-gnu --enable-shared && \
     make -j8 && \


### PR DESCRIPTION
We found the original location for libogg and libvorbis release sources was unresponsive: 
https://xiph.org/downloads/

This patch switches to pull the sources from github instead.